### PR TITLE
Add WithContext functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package bullettrain
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -45,8 +46,14 @@ func (c *Client) RemoveProxy() {
 
 // GetFeatures returns all features available in given environment
 func (c *Client) GetFeatures() ([]Flag, error) {
+	return c.GetFeaturesWithContext(context.TODO())
+}
+
+// GetFeaturesWithContext returns all features available in given environment
+func (c *Client) GetFeaturesWithContext(ctx context.Context) ([]Flag, error) {
 	flags := make([]Flag, 0)
 	_, err := c.client.NewRequest().
+		SetContext(ctx).
 		SetResult(&flags).
 		Get(c.config.BaseURI + "flags/")
 
@@ -55,8 +62,14 @@ func (c *Client) GetFeatures() ([]Flag, error) {
 
 // GetUserFeatures returns all features as defined for given user
 func (c *Client) GetUserFeatures(user User) ([]Flag, error) {
+	return c.GetUserFeaturesWithContext(context.TODO(), user)
+}
+
+// GetUserFeaturesWithContext returns all features as defined for given user
+func (c *Client) GetUserFeaturesWithContext(ctx context.Context, user User) ([]Flag, error) {
 	flags := make([]Flag, 0)
 	_, err := c.client.NewRequest().
+		SetContext(ctx).
 		SetResult(&flags).
 		Get(c.config.BaseURI + "flags/" + user.Identifier + "/")
 
@@ -65,7 +78,12 @@ func (c *Client) GetUserFeatures(user User) ([]Flag, error) {
 
 // HasFeature returns information whether given feature is defined
 func (c *Client) HasFeature(name string) (bool, error) {
-	flags, err := c.GetFeatures()
+	return c.HasFeatureWithContext(context.TODO(), name)
+}
+
+// HasFeatureWithContext returns information whether given feature is defined
+func (c *Client) HasFeatureWithContext(ctx context.Context, name string) (bool, error) {
+	flags, err := c.GetFeaturesWithContext(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -74,7 +92,12 @@ func (c *Client) HasFeature(name string) (bool, error) {
 
 // HasUserFeature returns information whether given feature is defined for given user
 func (c *Client) HasUserFeature(user User, name string) (bool, error) {
-	flags, err := c.GetUserFeatures(user)
+	return c.HasUserFeatureWithContext(context.TODO(), user, name)
+}
+
+// HasUserFeatureWithContext returns information whether given feature is defined for given user
+func (c *Client) HasUserFeatureWithContext(ctx context.Context, user User, name string) (bool, error) {
+	flags, err := c.GetUserFeaturesWithContext(ctx, user)
 	if err != nil {
 		return false, err
 	}
@@ -83,7 +106,12 @@ func (c *Client) HasUserFeature(user User, name string) (bool, error) {
 
 // FeatureEnabled returns information whether given feature flag is enabled
 func (c *Client) FeatureEnabled(name string) (bool, error) {
-	flags, err := c.GetFeatures()
+	return c.FeatureEnabledWithContext(context.TODO(), name)
+}
+
+// FeatureEnabledWithContext returns information whether given feature flag is enabled
+func (c *Client) FeatureEnabledWithContext(ctx context.Context, name string) (bool, error) {
+	flags, err := c.GetFeaturesWithContext(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -93,7 +121,13 @@ func (c *Client) FeatureEnabled(name string) (bool, error) {
 
 // UserFeatureEnabled returns information whether given feature flag is enabled for given user
 func (c *Client) UserFeatureEnabled(user User, name string) (bool, error) {
-	flags, err := c.GetUserFeatures(user)
+	return c.UserFeatureEnabledWithContext(context.TODO(), user, name)
+}
+
+// UserFeatureEnabled returns information whether given feature flag is enabled for given user
+func (c *Client) UserFeatureEnabledWithContext(ctx context.Context, user User, name string) (bool, error) {
+
+	flags, err := c.GetUserFeaturesWithContext(ctx, user)
 	if err != nil {
 		return false, err
 	}
@@ -105,7 +139,14 @@ func (c *Client) UserFeatureEnabled(user User, name string) (bool, error) {
 //
 // Returned value can have one of following types: bool, int, string
 func (c *Client) GetValue(name string) (interface{}, error) {
-	flags, err := c.GetFeatures()
+	return c.GetValueWithContext(context.TODO(), name)
+}
+
+// GetValueWithContext returns value of given feature (remote config)
+//
+// Returned value can have one of following types: bool, int, string
+func (c *Client) GetValueWithContext(ctx context.Context, name string) (interface{}, error) {
+	flags, err := c.GetFeaturesWithContext(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -121,7 +162,14 @@ func (c *Client) GetValue(name string) (interface{}, error) {
 //
 // Returned value can have one of following types: bool, int, string
 func (c *Client) GetUserValue(user User, name string) (interface{}, error) {
-	flags, err := c.GetUserFeatures(user)
+	return c.GetUserValueWithContext(context.TODO(), user, name)
+}
+
+// GetUserValueWithContext return value of given feature (remote config) as defined for given user
+//
+// Returned value can have one of following types: bool, int, string
+func (c *Client) GetUserValueWithContext(ctx context.Context, user User, name string) (interface{}, error) {
+	flags, err := c.GetUserFeaturesWithContext(ctx, user)
 	if err != nil {
 		return "", err
 	}
@@ -134,7 +182,12 @@ func (c *Client) GetUserValue(user User, name string) (interface{}, error) {
 
 // GetTrait returns trait defined for given user
 func (c *Client) GetTrait(user User, key string) (*Trait, error) {
-	traits, err := c.GetTraits(user, key)
+	return c.GetTraitWithContext(context.TODO(), user, key)
+}
+
+// GetTraitWithContext returns trait defined for given user
+func (c *Client) GetTraitWithContext(ctx context.Context, user User, key string) (*Trait, error) {
+	traits, err := c.GetTraitsWithContext(ctx, user, key)
 	if err != nil {
 		return nil, err
 	} else if len(traits) == 0 {
@@ -150,11 +203,21 @@ func (c *Client) GetTrait(user User, key string) (*Trait, error) {
 // If keys are provided, GetTrais returns only corresponding traits,
 // otherwise all traits for given user are returned.
 func (c *Client) GetTraits(user User, keys ...string) ([]*Trait, error) {
+	return c.GetTraitsWithContext(context.TODO(), user, keys...)
+}
+
+// GetTraitsWithContext returns traits defined for given user
+//
+// If keys are provided, GetTrais returns only corresponding traits,
+// otherwise all traits for given user are returned.
+
+func (c *Client) GetTraitsWithContext(ctx context.Context, user User, keys ...string) ([]*Trait, error) {
 	resp := struct {
 		Flags  []interface{} `json:"flags"`
 		Traits []*Trait      `json:"traits"`
 	}{}
 	_, err := c.client.NewRequest().
+		SetContext(ctx).
 		SetResult(&resp).
 		SetQueryParam("identifier", user.Identifier).
 		Get(c.config.BaseURI + "identities/")
@@ -181,10 +244,16 @@ func (c *Client) GetTraits(user User, keys ...string) ([]*Trait, error) {
 
 // UpdateTrait updates trait value
 func (c *Client) UpdateTrait(user User, toUpdate *Trait) (*Trait, error) {
+	return c.UpdateTraitWithContext(context.TODO(), user, toUpdate)
+}
+
+// UpdateTraitWithContext updates trait vaule with context
+func (c *Client) UpdateTraitWithContext(ctx context.Context, user User, toUpdate *Trait) (*Trait, error) {
 	toUpdate.Identity = user
 
 	trait := new(Trait)
 	_, err := c.client.NewRequest().
+		SetContext(ctx).
 		SetBody(toUpdate).
 		SetResult(trait).
 		Post(c.config.BaseURI + "traits/")
@@ -198,6 +267,15 @@ func (c *Client) UpdateTrait(user User, toUpdate *Trait) (*Trait, error) {
 // If object is a struct then the struct will be inspected
 // and each key value pair will be considered as a separate trait to be updated.
 func (c *Client) UpdateTraits(user User, object interface{}) ([]*Trait, error) {
+	return c.UpdateTraitsWithContext(context.TODO(), user, object)
+}
+
+// UpdateTraitsWithContext updates trait values in bulk.
+// The object argument may be a []Trait, []*Trait or a struct.
+// If object is []Trait or []*Trait then their Identity field may be mutated.
+// If object is a struct then the struct will be inspected
+// and each key value pair will be considered as a separate trait to be updated.
+func (c *Client) UpdateTraitsWithContext(ctx context.Context, user User, object interface{}) ([]*Trait, error) {
 	var bulkResp []*Trait = nil
 	var bulk []Trait = nil
 	switch traits := object.(type) {
@@ -239,6 +317,7 @@ func (c *Client) UpdateTraits(user User, object interface{}) ([]*Trait, error) {
 	}
 	bulkResp = make([]*Trait, len(bulk))
 	_, err := c.client.NewRequest().
+		SetContext(ctx).
 		SetBody(bulk).
 		SetResult(&bulkResp).
 		Put(c.config.BaseURI + "traits/bulk/")

--- a/client.go
+++ b/client.go
@@ -210,7 +210,6 @@ func (c *Client) GetTraits(user User, keys ...string) ([]*Trait, error) {
 //
 // If keys are provided, GetTrais returns only corresponding traits,
 // otherwise all traits for given user are returned.
-
 func (c *Client) GetTraitsWithContext(ctx context.Context, user User, keys ...string) ([]*Trait, error) {
 	resp := struct {
 		Flags  []interface{} `json:"flags"`

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package bullettrain_test
 
 import (
+	"context"
 	"testing"
 
 	bullettrain "github.com/BulletTrainHQ/bullet-train-go-client"
@@ -272,5 +273,23 @@ func TestRemoteConfig(t *testing.T) {
 	boolVal, ok := val.(bool)
 	assert.True(t, ok)
 	assert.Equal(t, true, boolVal)
+}
 
+func TestGetTraitsWithContextCancel(t *testing.T) {
+	c := bullettrain.DefaultClient(apiKey)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	traits, err := c.GetTraitsWithContext(ctx, testUser)
+
+	assert.Nil(t, traits)
+	assert.Error(t, err)
+}
+
+func TestGetFeatureFlagsWithContextCancel(t *testing.T) {
+	c := bullettrain.DefaultClient(apiKey)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := c.GetFeaturesWithContext(ctx)
+
+	assert.Error(t, err)
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -29,4 +30,15 @@ func main() {
 	for _, t := range traits {
 		fmt.Println(t.Key, "->", t.Value)
 	}
+
+	// use a Context, perhaps from an incomming Request
+	ctx := context.Background()
+	awesome, err = b.FeatureEnabledWithContext(ctx, "awesome_feature")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if awesome {
+		// do something awesome!
+	}
+
 }


### PR DESCRIPTION
A more idiomatic way of adding Context, without breaking existing API.

The other way I am considering is to move all the context-functions to a separate client instead, but appending "WithContext" tp function names seems to be the way it is done in http.Request.

I completely understand if this is too messy to add :)

This resolves issue #7.