### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/BulletTrainHQ/bullet-train-go-client
+module github.com/Flagsmith/flagsmith-go-client
 
 go 1.15
 


### PR DESCRIPTION
To reflect the new repository, and not require the use of the old repository when doing a `go mod tidy` as it looks to the module names for there import path.