### PR TITLE
Change import from bullettrain to flagsmith and rename packages

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-package bullettrain
+package flagsmith
 
 import (
 	"context"

--- a/client_test.go
+++ b/client_test.go
@@ -1,17 +1,17 @@
-package bullettrain_test
+package flagsmith_test
 
 import (
 	"context"
 	"testing"
 
-	bullettrain "github.com/BulletTrainHQ/bullet-train-go-client"
+	flagsmith "github.com/Flagsmith/flagsmith-go-client"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
 	apiKey               = "MgfUaRCvvZMznuQyqjnQKt"
-	testUser             = bullettrain.User{Identifier: "test_user"}
-	differentUser        = bullettrain.User{Identifier: "different_user"}
+	testUser             = flagsmith.User{Identifier: "test_user"}
+	differentUser        = flagsmith.User{Identifier: "different_user"}
 	testFeatureName      = "test_feature"
 	testFeatureValue     = "sample feature value"
 	testUserFeatureValue = "user feature value"
@@ -22,7 +22,7 @@ var (
 )
 
 func TestGetFeatureFlags(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	flags, err := c.GetFeatures()
 
 	assert.NoError(t, err)
@@ -36,7 +36,7 @@ func TestGetFeatureFlags(t *testing.T) {
 }
 
 func TestGetUserFeatureFlags(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	flags, err := c.GetUserFeatures(testUser)
 
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestGetUserFeatureFlags(t *testing.T) {
 }
 
 func TestGetFeatureFlagValue(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	val, err := c.GetValue(testFeatureName)
 
 	assert.NoError(t, err)
@@ -58,7 +58,7 @@ func TestGetFeatureFlagValue(t *testing.T) {
 }
 
 func TestGetUserFeatureFlagValue(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	val, err := c.GetUserValue(testUser, testFeatureName)
 
 	assert.NoError(t, err)
@@ -66,7 +66,7 @@ func TestGetUserFeatureFlagValue(t *testing.T) {
 }
 
 func TestHasFeature(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	enabled, err := c.HasFeature(testFeatureName)
 
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestHasFeature(t *testing.T) {
 }
 
 func TestHasUserFeature(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	enabled, err := c.HasUserFeature(testUser, testFeatureName)
 
 	assert.NoError(t, err)
@@ -82,7 +82,7 @@ func TestHasUserFeature(t *testing.T) {
 }
 
 func TestGetTrait(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	trait, err := c.GetTrait(testUser, testTraitName)
 
 	assert.NoError(t, err)
@@ -90,7 +90,7 @@ func TestGetTrait(t *testing.T) {
 }
 
 func TestGetTraits(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	traits, err := c.GetTraits(testUser)
 
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestGetTraits(t *testing.T) {
 }
 
 func TestUpdateTrait(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	trait, err := c.GetTrait(differentUser, testTraitName)
 	assert.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestUpdateTrait(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func updateTraitsAsserts(updated []*bullettrain.Trait, err error, c *bullettrain.Client, t *testing.T) {
+func updateTraitsAsserts(updated []*flagsmith.Trait, err error, c *flagsmith.Client, t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, updated)
 	assert.Equal(t, 5, len(updated))
@@ -151,31 +151,31 @@ func updateTraitsAsserts(updated []*bullettrain.Trait, err error, c *bullettrain
 }
 
 func TestBulkUpdateTraitsPointers(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 
-	traits := []*bullettrain.Trait{
+	traits := []*flagsmith.Trait{
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "boolField",
 			Value:    "true",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "intField",
 			Value:    "42",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "stringField",
 			Value:    "foo bar baz",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "anotherField",
 			Value:    "616",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "floatField",
 			Value:    "3.14",
 		},
@@ -185,7 +185,7 @@ func TestBulkUpdateTraitsPointers(t *testing.T) {
 }
 
 func TestBulkUpdateTraitsObject(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 
 	object := struct {
 		boolField    bool
@@ -202,31 +202,31 @@ func TestBulkUpdateTraitsObject(t *testing.T) {
 }
 
 func TestBulkUpdateTraits(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 
-	traits := []bullettrain.Trait{
+	traits := []flagsmith.Trait{
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "boolField",
 			Value:    "true",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "intField",
 			Value:    "42",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "stringField",
 			Value:    "foo bar baz",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "anotherField",
 			Value:    "616",
 		},
 		{
-			Identity: bullettrain.User{},
+			Identity: flagsmith.User{},
 			Key:      "floatField",
 			Value:    "3.14",
 		},
@@ -237,21 +237,21 @@ func TestBulkUpdateTraits(t *testing.T) {
 }
 
 func TestFeatureEnabled(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	enabled, err := c.FeatureEnabled(testFlagName)
 	assert.NoError(t, err)
 	assert.Equal(t, testFlagValue, enabled)
 }
 
 func TestUserFeatureEnabled(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	enabled, err := c.UserFeatureEnabled(testUser, testFlagName)
 	assert.NoError(t, err)
 	assert.Equal(t, testFlagValue, enabled)
 }
 
 func TestRemoteConfig(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 
 	// string
 	val, err := c.GetValue(testFeatureName)
@@ -276,7 +276,7 @@ func TestRemoteConfig(t *testing.T) {
 }
 
 func TestGetTraitsWithContextCancel(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	traits, err := c.GetTraitsWithContext(ctx, testUser)
@@ -286,7 +286,7 @@ func TestGetTraitsWithContextCancel(t *testing.T) {
 }
 
 func TestGetFeatureFlagsWithContextCancel(t *testing.T) {
-	c := bullettrain.DefaultClient(apiKey)
+	c := flagsmith.DefaultClient(apiKey)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := c.GetFeaturesWithContext(ctx)

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-package bullettrain
+package flagsmith
 
 import "time"
 

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -23,7 +23,7 @@ func main() {
 		// do something awesome!
 	}
 
-	traits, err := b.GetTraits(flagsmith.User{"test_user"})
+	traits, err := b.GetTraits(flagsmith.User{Identifier: "test_user"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"time"
 
-	bullettrain "github.com/BulletTrainHQ/bullet-train-go-client"
+	"github.com/Flagsmith/flagsmith-go-client"
 )
 
 func main() {
-	b := bullettrain.NewClient("MgfUaRCvvZMznuQyqjnQKt", bullettrain.Config{
+	b := flagsmith.NewClient("MgfUaRCvvZMznuQyqjnQKt", flagsmith.Config{
 		Timeout: 3 * time.Second,
 		BaseURI: "https://api.bullet-train.io/api/v1/", // what a coincidence ;)
 	})
@@ -23,7 +23,7 @@ func main() {
 		// do something awesome!
 	}
 
-	traits, err := b.GetTraits(bullettrain.User{"test_user"})
+	traits, err := b.GetTraits(flagsmith.User{"test_user"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package bullettrain
+package flagsmith
 
 // Feature contains core information about feature
 type Feature struct {


### PR DESCRIPTION
This resolves issue #11 and along with that cleans up the rest of the naming.

The  2nd commit changes an un-keyed struct constructor to a keyed one.