### PR TITLE
Use local context when fetching flags

### DIFF
--- a/example/server.go
+++ b/example/server.go
@@ -42,7 +42,6 @@ func RootHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Intialise the flagsmith client
 	client := flagsmith.NewClient(os.Getenv("FLAGSMITH_ENVIRONMENT_KEY"),
-		flagsmith.WithContext(ctx),
 		flagsmith.WithDefaultHandler(DefaultFlagHandler),
 	)
 	q := r.URL.Query()
@@ -57,7 +56,7 @@ func RootHandler(w http.ResponseWriter, r *http.Request) {
 			traits = []*flagsmith.Trait{&trait}
 		}
 
-		flags, _ := client.GetIdentityFlags(identifier, traits)
+		flags, _ := client.GetIdentityFlags(ctx, identifier, traits)
 
 		showButton, _ := flags.IsFeatureEnabled("secret_button")
 		buttonData, _ := flags.GetFeatureValue("secret_button")
@@ -76,7 +75,7 @@ func RootHandler(w http.ResponseWriter, r *http.Request) {
 		_ = t.Execute(w, templateData)
 		return
 	}
-	flags, _ := client.GetEnvironmentFlags()
+	flags, _ := client.GetEnvironmentFlags(ctx)
 
 	showButton, _ := flags.IsFeatureEnabled("secret_button")
 


### PR DESCRIPTION
The context provided with WithContext() during setup of the client will most likely live for the entire duration of the program, so it doesn't really do that much when provided to the HTTP client reaching out to fetch the feature flags.

A better option is to provide a context when needing these functions, which would allow the caller to cancel them earlier if needed.

Also removed context from functions that weren't using them.