### PR TITLE
Make local evaluation non-blocking

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -455,7 +455,7 @@ func TestWithProxyClientOption(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
 	defer server.Close()
 
-	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithProxy(server.URL),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(), flagsmith.WithProxy(server.URL),
 		flagsmith.WithBaseURL("http://some-other-url-that-should-not-be-used/api/v1/"))
 
 	err := client.UpdateEnvironment(context.Background())

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package flagsmith_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -317,8 +318,8 @@ func TestFlagsmithAPIErrorIsReturnedIfRequestFailsWithoutDefaultHandler(t *testi
 
 	_, err := client.GetEnvironmentFlags()
 	assert.Error(t, err)
-	_, ok := err.(*flagsmith.FlagsmithAPIError)
-	assert.True(t, ok)
+	var flagErr *flagsmith.FlagsmithAPIError
+	assert.True(t, errors.As(err, &flagErr))
 }
 
 func TestGetIdentitySegmentsNoTraits(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -152,8 +152,7 @@ func (f *Flags) GetFlag(featureName string) (Flag, error) {
 		if f.defaultFlagHandler != nil {
 			return f.defaultFlagHandler(featureName), nil
 		}
-		msg := fmt.Sprintf("flagsmith: No feature found with name %s", featureName)
-		return resultFlag, &FlagsmithClientError{msg}
+		return resultFlag, &FlagsmithClientError{fmt.Sprintf("flagsmith: No feature found with name %q", featureName)}
 	}
 	if f.analyticsProcessor != nil {
 		f.analyticsProcessor.TrackFeature(resultFlag.FeatureName)


### PR DESCRIPTION
If local evaluation is enabled then the primary functions used to
fetch the flags will not reach out to the API (which could block for
several seconds), but instead use the environment or directly go to
the default flag handler.

This change will make so that execution of the program will always
be snappy, even in the case of flaky network connection. Also the
*FromAPI() functions will actually return an error in case they fail
to get the latest information from the API instead of using the
default flag handler.

While these aren't _really_ breaking changes, they significantly
alter how and when errors are returned and I would suggest this is
a major release change.