### PR TITLE
Allow defaultFlagHandler to return an error

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ type Client struct {
 	environment atomic.Value
 
 	analyticsProcessor *AnalyticsProcessor
-	defaultFlagHandler func(string) Flag
+	defaultFlagHandler func(string) (Flag, error)
 
 	client *resty.Client
 	ctx    context.Context

--- a/client_test.go
+++ b/client_test.go
@@ -117,8 +117,8 @@ func TestGetEnvironmentFlagsCallsAPIWhenLocalEnvironmentNotAvailable(t *testing.
 
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
-		flagsmith.WithDefaultHandler(func(featureName string) flagsmith.Flag {
-			return flagsmith.Flag{IsDefault: true}
+		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
+			return flagsmith.Flag{IsDefault: true}, nil
 		}))
 
 	flags, err := client.GetEnvironmentFlags()
@@ -241,8 +241,8 @@ func TestDefaultHandlerIsUsedWhenNoMatchingEnvironmentFlagReturned(t *testing.T)
 
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
-		flagsmith.WithDefaultHandler(func(featureName string) flagsmith.Flag {
-			return flagsmith.Flag{IsDefault: true}
+		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
+			return flagsmith.Flag{IsDefault: true}, nil
 		}))
 
 	flags, err := client.GetEnvironmentFlags()
@@ -273,8 +273,8 @@ func TestDefaultHandlerIsUsedWhenTimeout(t *testing.T) {
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
 		flagsmith.WithRequestTimeout(10*time.Millisecond),
-		flagsmith.WithDefaultHandler(func(featureName string) flagsmith.Flag {
-			return flagsmith.Flag{IsDefault: true}
+		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
+			return flagsmith.Flag{IsDefault: true}, nil
 		}))
 
 	flags, err := client.GetEnvironmentFlags()
@@ -294,8 +294,8 @@ func TestDefaultHandlerIsUsedWhenRequestFails(t *testing.T) {
 
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
-		flagsmith.WithDefaultHandler(func(featureName string) flagsmith.Flag {
-			return flagsmith.Flag{IsDefault: true}
+		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
+			return flagsmith.Flag{IsDefault: true}, nil
 		}))
 
 	flags, err := client.GetEnvironmentFlags()

--- a/example/server.go
+++ b/example/server.go
@@ -27,13 +27,13 @@ type TemplateData struct {
 	ButtonColour string
 }
 
-func DefaultFlagHandler(featureName string) flagsmith.Flag {
+func DefaultFlagHandler(featureName string) (flagsmith.Flag, error) {
 	return flagsmith.Flag{
 		FeatureName: featureName,
 		IsDefault:   true,
 		Value:       `{"colour": "#FFFF00"}`,
 		Enabled:     true,
-	}
+	}, nil
 }
 
 func RootHandler(w http.ResponseWriter, r *http.Request) {

--- a/models.go
+++ b/models.go
@@ -47,12 +47,12 @@ func makeFlagFromFeatureState(featureState *features.FeatureStateModel, identity
 type Flags struct {
 	flags              []Flag
 	analyticsProcessor *AnalyticsProcessor
-	defaultFlagHandler func(featureName string) Flag
+	defaultFlagHandler func(featureName string) (Flag, error)
 }
 
 func makeFlagsFromFeatureStates(featureStates []*features.FeatureStateModel,
 	analyticsProcessor *AnalyticsProcessor,
-	defaultFlagHandler func(featureName string) Flag,
+	defaultFlagHandler func(featureName string) (Flag, error),
 	identityID string) Flags {
 	flags := make([]Flag, len(featureStates))
 	for i, featureState := range featureStates {
@@ -86,7 +86,7 @@ func (jf *jsonFlag) toFlag() Flag {
 		FeatureName: jf.Feature.Name,
 	}
 }
-func makeFlagsFromAPIFlags(flagsJson []byte, analyticsProcessor *AnalyticsProcessor, defaultFlagHandler func(string) Flag) (Flags, error) {
+func makeFlagsFromAPIFlags(flagsJson []byte, analyticsProcessor *AnalyticsProcessor, defaultFlagHandler func(string) (Flag, error)) (Flags, error) {
 	var jsonflags []jsonFlag
 	err := json.Unmarshal(flagsJson, &jsonflags)
 	if err != nil {
@@ -102,7 +102,7 @@ func makeFlagsFromAPIFlags(flagsJson []byte, analyticsProcessor *AnalyticsProces
 		defaultFlagHandler: defaultFlagHandler,
 	}, err
 }
-func makeFlagsfromIdentityAPIJson(jsonResponse []byte, analyticsProcessor *AnalyticsProcessor, defaultFlagHandler func(string) Flag) (Flags, error) {
+func makeFlagsfromIdentityAPIJson(jsonResponse []byte, analyticsProcessor *AnalyticsProcessor, defaultFlagHandler func(string) (Flag, error)) (Flags, error) {
 	resonse := struct {
 		Flags interface{} `json:"flags"`
 	}{}
@@ -150,7 +150,7 @@ func (f *Flags) GetFlag(featureName string) (Flag, error) {
 	}
 	if resultFlag.FeatureID == 0 {
 		if f.defaultFlagHandler != nil {
-			return f.defaultFlagHandler(featureName), nil
+			return f.defaultFlagHandler(featureName)
 		}
 		return resultFlag, &FlagsmithClientError{fmt.Sprintf("flagsmith: No feature found with name %q", featureName)}
 	}

--- a/options.go
+++ b/options.go
@@ -71,7 +71,7 @@ func WithCustomHeaders(headers map[string]string) Option {
 	}
 }
 
-func WithDefaultHandler(handler func(string) Flag) Option {
+func WithDefaultHandler(handler func(string) (Flag, error)) Option {
 	return func(c *Client) {
 		c.defaultFlagHandler = handler
 	}


### PR DESCRIPTION
Currently the signature of the default Flag handler only allows for a flag to be returned, with no way to signal back in case something goes wrong when trying to find the requested feature.

This is different behavior compared to how it works when querying the FlagsmithAPI, which is why we now try to align it.

With this change we would be able to write a handler like this:

```go
  func improvedDefaultHandler(feature string) (Flag, error) {
    switch feature {
    case "exists":
      return Flag{FeatureName: "exists", Value: "nice" }, nil
    default:
      return Flag{}, fmt.Errorf("feature %q does not exist", feature)
    }
  }
```