### PR TITLE
Track all feature flag calls

### DIFF
--- a/models.go
+++ b/models.go
@@ -142,6 +142,10 @@ func (f *Flags) IsFeatureEnabled(featureName string) (bool, error) {
 
 // Returns a specific flag given the name of the feature.
 func (f *Flags) GetFlag(featureName string) (Flag, error) {
+	if f.analyticsProcessor != nil {
+		f.analyticsProcessor.TrackFeature(featureName)
+	}
+
 	var resultFlag Flag
 	for _, flag := range f.flags {
 		if flag.FeatureName == featureName {
@@ -153,9 +157,6 @@ func (f *Flags) GetFlag(featureName string) (Flag, error) {
 			return f.defaultFlagHandler(featureName)
 		}
 		return resultFlag, &FlagsmithClientError{fmt.Sprintf("flagsmith: No feature found with name %q", featureName)}
-	}
-	if f.analyticsProcessor != nil {
-		f.analyticsProcessor.TrackFeature(resultFlag.FeatureName)
 	}
 	return resultFlag, nil
 }


### PR DESCRIPTION
If an analytics processor exists we previouly only tracked feature flag names that were present either from the environment or from the API. However, this gave us no information about calls to flags that either were wrong, or were handled by the default handler.

With this change we now track all calls for more extensive coverage.