### PR TITLE
refactor: handle invalid environment key

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,7 +35,7 @@ type Client struct {
 }
 
 // NewClient creates instance of Client with given configuration.
-func NewClient(apiKey string, options ...Option) (*Client, error) {
+func NewClient(apiKey string, options ...Option) *Client {
 	c := &Client{
 		apiKey: apiKey,
 		config: defaultConfig(),
@@ -56,7 +56,7 @@ func NewClient(apiKey string, options ...Option) (*Client, error) {
 
 	if c.config.localEvaluation {
 		if !strings.HasPrefix(apiKey, "ser.") {
-			return nil, errors.New("In order to use local evaluation, please generate a server key in the environment settings page.")
+			panic("In order to use local evaluation, please generate a server key in the environment settings page.")
 		}
 
 		go c.pollEnvironment(c.ctxLocalEval)
@@ -66,7 +66,7 @@ func NewClient(apiKey string, options ...Option) (*Client, error) {
 		c.analyticsProcessor = NewAnalyticsProcessor(c.ctxAnalytics, c.client, c.config.baseURL, nil, c.log)
 	}
 
-	return c, nil
+	return c
 }
 
 // Returns `Flags` struct holding all the flags for the current environment.

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -34,7 +35,7 @@ type Client struct {
 }
 
 // NewClient creates instance of Client with given configuration.
-func NewClient(apiKey string, options ...Option) *Client {
+func NewClient(apiKey string, options ...Option) (*Client, error) {
 	c := &Client{
 		apiKey: apiKey,
 		config: defaultConfig(),
@@ -54,6 +55,10 @@ func NewClient(apiKey string, options ...Option) *Client {
 	c.client.SetLogger(c.log)
 
 	if c.config.localEvaluation {
+		if !strings.HasPrefix(apiKey, "ser.") {
+			return nil, errors.New("In order to use local evaluation, please generate a server key in the environment settings page.")
+		}
+
 		go c.pollEnvironment(c.ctxLocalEval)
 	}
 	// Initialize analytics processor
@@ -61,7 +66,7 @@ func NewClient(apiKey string, options ...Option) *Client {
 		c.analyticsProcessor = NewAnalyticsProcessor(c.ctxAnalytics, c.client, c.config.baseURL, nil, c.log)
 	}
 
-	return c
+	return c, nil
 }
 
 // Returns `Flags` struct holding all the flags for the current environment.

--- a/client_test.go
+++ b/client_test.go
@@ -93,7 +93,6 @@ func TestGetEnvironmentFlagsUseslocalEnvironmentWhenAvailable(t *testing.T) {
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-
 	err := client.UpdateEnvironment(ctx)
 
 	// Then
@@ -167,7 +166,6 @@ func TestGetIdentityFlagsUseslocalEnvironmentWhenAvailable(t *testing.T) {
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-
 	err := client.UpdateEnvironment(ctx)
 
 	// Then

--- a/client_test.go
+++ b/client_test.go
@@ -18,8 +18,9 @@ import (
 
 func TestClientErrorsIfLocalEvaluationWithNonServerSideKey(t *testing.T) {
 	// When, Then
-	_, err := flagsmith.NewClient("key", flagsmith.WithLocalEvaluation(context.Background()))
-	assert.Error(t, err)
+	assert.Panics(t, func() {
+		_ = flagsmith.NewClient("key", flagsmith.WithLocalEvaluation(context.Background()))
+	})
 }
 
 func TestClientUpdatesEnvironmentOnStartForLocalEvaluation(t *testing.T) {
@@ -39,9 +40,8 @@ func TestClientUpdatesEnvironmentOnStartForLocalEvaluation(t *testing.T) {
 	defer server.Close()
 
 	// When
-	_, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	_ = flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
 	// Sleep to ensure that the server has time to update the environment
 	time.Sleep(10 * time.Millisecond)
@@ -69,10 +69,9 @@ func TestClientUpdatesEnvironmentOnEachRefresh(t *testing.T) {
 	defer server.Close()
 
 	// When
-	_, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	_ = flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithEnvironmentRefreshInterval(100*time.Millisecond),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
 	time.Sleep(250 * time.Millisecond)
 
@@ -92,11 +91,10 @@ func TestGetEnvironmentFlagsUseslocalEnvironmentWhenAvailable(t *testing.T) {
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
-	err = client.UpdateEnvironment(ctx)
+	err := client.UpdateEnvironment(ctx)
 
 	// Then
 	assert.NoError(t, err)
@@ -130,11 +128,10 @@ func TestGetEnvironmentFlagsCallsAPIWhenLocalEnvironmentNotAvailable(t *testing.
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
 		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
 			return flagsmith.Flag{IsDefault: true}, nil
 		}))
-	assert.NoError(t, err)
 
 	flags, err := client.GetEnvironmentFlags(ctx)
 
@@ -168,11 +165,10 @@ func TestGetIdentityFlagsUseslocalEnvironmentWhenAvailable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
 	defer server.Close()
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
-	err = client.UpdateEnvironment(ctx)
+	err := client.UpdateEnvironment(ctx)
 
 	// Then
 	assert.NoError(t, err)
@@ -217,9 +213,8 @@ func TestGetIdentityFlagsCallsAPIWhenLocalEnvironmentNotAvailableWithTraits(t *t
 	}))
 	defer server.Close()
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey,
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey,
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
 	stringTrait := flagsmith.Trait{TraitKey: "stringTrait", TraitValue: "trait_value"}
 	intTrait := flagsmith.Trait{TraitKey: "intTrait", TraitValue: 1}
@@ -261,11 +256,10 @@ func TestDefaultHandlerIsUsedWhenNoMatchingEnvironmentFlagReturned(t *testing.T)
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
 		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
 			return flagsmith.Flag{IsDefault: true}, nil
 		}))
-	assert.NoError(t, err)
 
 	flags, err := client.GetEnvironmentFlags(ctx)
 
@@ -294,12 +288,11 @@ func TestDefaultHandlerIsUsedWhenTimeout(t *testing.T) {
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
 		flagsmith.WithRequestTimeout(10*time.Millisecond),
 		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
 			return flagsmith.Flag{IsDefault: true}, nil
 		}))
-	assert.NoError(t, err)
 
 	flags, err := client.GetEnvironmentFlags(ctx)
 
@@ -318,11 +311,10 @@ func TestDefaultHandlerIsUsedWhenRequestFails(t *testing.T) {
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"),
 		flagsmith.WithDefaultHandler(func(featureName string) (flagsmith.Flag, error) {
 			return flagsmith.Flag{IsDefault: true}, nil
 		}))
-	assert.NoError(t, err)
 
 	flags, err := client.GetEnvironmentFlags(ctx)
 
@@ -341,10 +333,9 @@ func TestFlagsmithAPIErrorIsReturnedIfRequestFailsWithoutDefaultHandler(t *testi
 	defer server.Close()
 
 	// When
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
 
-	_, err = client.GetEnvironmentFlags(ctx)
+	_, err := client.GetEnvironmentFlags(ctx)
 	assert.Error(t, err)
 	var flagErr *flagsmith.FlagsmithClientError
 	assert.True(t, errors.As(err, &flagErr))
@@ -356,11 +347,10 @@ func TestGetIdentitySegmentsNoTraits(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
 	defer server.Close()
 
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
-	err = client.UpdateEnvironment(ctx)
+	err := client.UpdateEnvironment(ctx)
 	assert.NoError(t, err)
 
 	segments, err := client.GetIdentitySegments("test_identity", nil)
@@ -375,11 +365,10 @@ func TestGetIdentitySegmentsWithTraits(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
 	defer server.Close()
 
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx),
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
 
-	err = client.UpdateEnvironment(ctx)
+	err := client.UpdateEnvironment(ctx)
 	assert.NoError(t, err)
 
 	// lifted from fixtures/EnvironmentJson
@@ -417,11 +406,10 @@ func TestBulkIdentifyReturnsErrorIfBatchSizeIsTooLargeToProcess(t *testing.T) {
 
 	}))
 	defer server.Close()
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
 
 	// When
-	err = client.BulkIdentify(ctx, data)
+	err := client.BulkIdentify(ctx, data)
 
 	// Then
 	assert.Error(t, err)
@@ -437,11 +425,10 @@ func TestBulkIdentifyReturnsErrorIfServerReturns404(t *testing.T) {
 		rw.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
 
 	// When
-	err = client.BulkIdentify(ctx, data)
+	err := client.BulkIdentify(ctx, data)
 
 	// Then
 	assert.Error(t, err)
@@ -479,11 +466,10 @@ func TestBulkIdentify(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
-	assert.NoError(t, err)
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithBaseURL(server.URL+"/api/v1/"))
 
 	// When
-	err = client.BulkIdentify(ctx, data)
+	err := client.BulkIdentify(ctx, data)
 
 	// Then
 	assert.NoError(t, err)
@@ -495,11 +481,10 @@ func TestWithProxyClientOption(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
 	defer server.Close()
 
-	client, err := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx), flagsmith.WithProxy(server.URL),
+	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey, flagsmith.WithLocalEvaluation(ctx), flagsmith.WithProxy(server.URL),
 		flagsmith.WithBaseURL("http://some-other-url-that-should-not-be-used/api/v1/"))
-	assert.NoError(t, err)
 
-	err = client.UpdateEnvironment(ctx)
+	err := client.UpdateEnvironment(ctx)
 
 	// Then
 	assert.NoError(t, err)

--- a/example/server.go
+++ b/example/server.go
@@ -13,7 +13,17 @@ import (
 )
 
 func main() {
-	http.HandleFunc("/", RootHandler)
+	// Intialise the flagsmith client
+	client, err := flagsmith.NewClient(os.Getenv("FLAGSMITH_ENVIRONMENT_KEY"),
+		flagsmith.WithDefaultHandler(DefaultFlagHandler),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	h := Handler{client}
+
+	http.HandleFunc("/", h.RootHandler)
 
 	fmt.Printf("Starting server at port 5000\n")
 	if err := http.ListenAndServe(":5000", nil); err != nil {
@@ -36,14 +46,14 @@ func DefaultFlagHandler(featureName string) (flagsmith.Flag, error) {
 	}, nil
 }
 
-func RootHandler(w http.ResponseWriter, r *http.Request) {
+type Handler struct {
+	client *flagsmith.Client
+}
+
+func (h Handler) RootHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	// Intialise the flagsmith client
-	client := flagsmith.NewClient(os.Getenv("FLAGSMITH_ENVIRONMENT_KEY"),
-		flagsmith.WithDefaultHandler(DefaultFlagHandler),
-	)
 	q := r.URL.Query()
 
 	if q.Get("identifier") != "" {
@@ -56,7 +66,7 @@ func RootHandler(w http.ResponseWriter, r *http.Request) {
 			traits = []*flagsmith.Trait{&trait}
 		}
 
-		flags, _ := client.GetIdentityFlags(ctx, identifier, traits)
+		flags, _ := h.client.GetIdentityFlags(ctx, identifier, traits)
 
 		showButton, _ := flags.IsFeatureEnabled("secret_button")
 		buttonData, _ := flags.GetFeatureValue("secret_button")
@@ -75,7 +85,7 @@ func RootHandler(w http.ResponseWriter, r *http.Request) {
 		_ = t.Execute(w, templateData)
 		return
 	}
-	flags, _ := client.GetEnvironmentFlags(ctx)
+	flags, _ := h.client.GetEnvironmentFlags(ctx)
 
 	showButton, _ := flags.IsFeatureEnabled("secret_button")
 

--- a/example/server.go
+++ b/example/server.go
@@ -14,12 +14,9 @@ import (
 
 func main() {
 	// Intialise the flagsmith client
-	client, err := flagsmith.NewClient(os.Getenv("FLAGSMITH_ENVIRONMENT_KEY"),
+	client := flagsmith.NewClient(os.Getenv("FLAGSMITH_ENVIRONMENT_KEY"),
 		flagsmith.WithDefaultHandler(DefaultFlagHandler),
 	)
-	if err != nil {
-		panic(err)
-	}
 
 	h := Handler{client}
 

--- a/fixtures/fixture.go
+++ b/fixtures/fixture.go
@@ -6,7 +6,7 @@ import (
 )
 
 const BaseURL = "http://localhost:8000/api/v1/"
-const EnvironmentAPIKey = "test_key"
+const EnvironmentAPIKey = "ser.test_key"
 const Feature1Value = "some_value"
 const Feature1Name = "feature_1"
 const Feature1ID = 1


### PR DESCRIPTION
👋 I've had a go at resolving #6. Please let me know what you think. I've changed the return type of `NewClient`. Alternatively, it can panic, but I think it is more idiomatic to return the error. I've also updated the example in `example/server.go`.

Fixes #6.