### PR TITLE
feat: Use RFC 3339, more lax datetime parsing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,17 +6,23 @@ on:
   pull_request:
 
 jobs:
-
   build:
     if: github.event.pull_request.draft == false
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    strategy:
+      max-parallel: 2
+      matrix:
+        go-version:
+          - stable
+          - oldstable
+
+    steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: ${{ matrix.go-version }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: stable
           cache: true
       - uses: goreleaser/goreleaser-action@v5
         with:

--- a/flagengine/utils/time.go
+++ b/flagengine/utils/time.go
@@ -3,19 +3,19 @@ package utils
 import (
 	"strings"
 	"time"
-)
 
-const iso8601 = "2006-01-02T15:04:05.999999"
+	"github.com/itlightning/dateparse"
+)
 
 type ISOTime struct {
 	time.Time
 }
 
 func (i *ISOTime) UnmarshalJSON(bytes []byte) (err error) {
-	i.Time, err = time.Parse(iso8601, strings.Trim(string(bytes), `"`))
+	i.Time, err = dateparse.ParseAny(strings.Trim(string(bytes), `"`))
 	return
 }
 
 func (i *ISOTime) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + i.Time.Format(iso8601) + `"`), nil
+	return []byte(`"` + i.Time.Format(time.RFC3339) + `"`), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 )
 
+require github.com/itlightning/dateparse v0.2.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/itlightning/dateparse v0.2.0 h1:eOYLGZORnHweKdTZGOVjDXHhOwMQTNdP4g6+ErgPyeg=
+github.com/itlightning/dateparse v0.2.0/go.mod h1:W2PH6/Sq+PuJJ6JUgx2nau+ew1KLGXwoGP1A240x204=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
This PR is a necessary change to accommodate for the new server-side datetime serialisation — current strict ISO 8601 format couldn't process some of Pydantic's output.