### PR TITLE
feat: Add a configurable error handler for environment updates. Return response codes on HTTP errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,11 +26,12 @@ type Client struct {
 	analyticsProcessor *AnalyticsProcessor
 	defaultFlagHandler func(string) (Flag, error)
 
-	client         *resty.Client
-	ctxLocalEval   context.Context
-	ctxAnalytics   context.Context
-	log            Logger
-	offlineHandler OfflineHandler
+	client           *resty.Client
+	ctxLocalEval     context.Context
+	ctxAnalytics     context.Context
+	log              Logger
+	offlineHandler   OfflineHandler
+	pollErrorHandler func(error)
 }
 
 // NewClient creates instance of Client with given configuration.
@@ -244,6 +245,9 @@ func (c *Client) pollEnvironment(ctx context.Context) {
 		err := c.UpdateEnvironment(ctx)
 		if err != nil {
 			c.log.Errorf("Failed to update environment: %v", err)
+			if c.pollErrorHandler != nil {
+			    c.pollErrorHandler(err)
+			}
 		}
 	}
 	update()

--- a/client_export_test.go
+++ b/client_export_test.go
@@ -1,0 +1,7 @@
+package flagsmith
+
+import "context"
+
+func PollEnvironment(client *Client, ctx context.Context) {
+    client.pollEnvironment(ctx)
+}

--- a/client_export_test.go
+++ b/client_export_test.go
@@ -1,7 +1,0 @@
-package flagsmith
-
-import "context"
-
-func PollEnvironment(client *Client, ctx context.Context) {
-    client.pollEnvironment(ctx)
-}

--- a/client_test.go
+++ b/client_test.go
@@ -691,8 +691,7 @@ func TestPollErrorHandlerIsUsedWhenPollFails(t *testing.T) {
 	// When
 	client := flagsmith.NewClient(fixtures.EnvironmentAPIKey,
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"),
-		flagsmith.WithEnvironmentRefreshInterval(time.Duration(2)*time.Second),
-		flagsmith.WithErrorHandler(func(handler flagsmith.FlagsmithErrorHandler) {
+		flagsmith.WithErrorHandler(func(handler *flagsmith.FlagsmithAPIError) {
 			capturedError = handler.Err
 			statusCode = handler.ResponseStatusCode
 			status = handler.ResponseStatus

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,12 @@ type FlagsmithAPIError struct {
 	msg string
 }
 
+type FlagsmithErrorHandler struct {
+	Err                error
+	ResponseStatusCode int
+	ResponseStatus     string
+}
+
 func (e FlagsmithClientError) Error() string {
 	return e.msg
 }

--- a/errors.go
+++ b/errors.go
@@ -5,10 +5,7 @@ type FlagsmithClientError struct {
 }
 
 type FlagsmithAPIError struct {
-	msg string
-}
-
-type FlagsmithErrorHandler struct {
+	Msg                string
 	Err                error
 	ResponseStatusCode int
 	ResponseStatus     string
@@ -19,5 +16,5 @@ func (e FlagsmithClientError) Error() string {
 }
 
 func (e FlagsmithAPIError) Error() string {
-	return e.msg
+	return e.Msg
 }

--- a/options.go
+++ b/options.go
@@ -119,7 +119,7 @@ func WithOfflineMode() Option {
 }
 
 // WithErrorHandler provides a way to handle errors that occur during update of an environment
-func WithErrorHandler(handler func(handler FlagsmithErrorHandler)) Option {
+func WithErrorHandler(handler func(handler *FlagsmithAPIError)) Option {
 	return func(c *Client) {
 		c.errorHandler = handler
 	}

--- a/options.go
+++ b/options.go
@@ -118,7 +118,7 @@ func WithOfflineMode() Option {
 	}
 }
 
-// WithErrorHandler provides a way to handle errors that occur during update of an environment
+// WithErrorHandler provides a way to handle errors that occur during update of an environment.
 func WithErrorHandler(handler func(handler *FlagsmithAPIError)) Option {
 	return func(c *Client) {
 		c.errorHandler = handler

--- a/options.go
+++ b/options.go
@@ -118,9 +118,9 @@ func WithOfflineMode() Option {
 	}
 }
 
-// WithPollErrorHandler provides a way to handle errors that occur during polling of environment
-func WithPollErrorHandler(handler func(err error)) Option {
-    return func(c *Client) {
-        c.pollErrorHandler = handler
-    }
+// WithErrorHandler provides a way to handle errors that occur during update of an environment
+func WithErrorHandler(handler func(handler FlagsmithErrorHandler)) Option {
+	return func(c *Client) {
+		c.errorHandler = handler
+	}
 }

--- a/options.go
+++ b/options.go
@@ -117,3 +117,10 @@ func WithOfflineMode() Option {
 		c.config.offlineMode = true
 	}
 }
+
+// WithPollErrorHandler provides a way to handle errors that occur during polling of environment
+func WithPollErrorHandler(handler func(err error)) Option {
+    return func(c *Client) {
+        c.pollErrorHandler = handler
+    }
+}


### PR DESCRIPTION
- Adds a `pollErrorHandler func(error)` to `Client` struct. 
- Instead of just logging exception in `pollEnvironment()`, trigger callback function when UpdateEnvironment fails.