### PR TITLE
fix: Improve SSE connection error handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.61.0
+    rev: v1.64.6
     hooks:
       - id: golangci-lint

--- a/realtime.go
+++ b/realtime.go
@@ -30,6 +30,9 @@ func (c *Client) startRealtimeUpdates(ctx context.Context) {
 				c.log.Errorf("Error connecting to realtime server: %v", err)
 				continue
 			}
+			if resp.Header.Get("Content-Type") != "text/event-stream" {
+				panic("realtime server did not open an SSE connection")
+			}
 			defer resp.Body.Close()
 
 			scanner := bufio.NewScanner(resp.Body)

--- a/realtime.go
+++ b/realtime.go
@@ -28,6 +28,7 @@ func (c *Client) startRealtimeUpdates(ctx context.Context) {
 			resp, err := http.Get(stream_url)
 			if err != nil {
 				c.log.Errorf("Error connecting to realtime server: %v", err)
+				time.Sleep(c.client.RetryWaitTime)
 				continue
 			}
 			if resp.Header.Get("Content-Type") != "text/event-stream" {

--- a/realtime.go
+++ b/realtime.go
@@ -31,10 +31,10 @@ func (c *Client) startRealtimeUpdates(ctx context.Context) {
 				time.Sleep(c.client.RetryWaitTime)
 				continue
 			}
+			defer resp.Body.Close()
 			if resp.Header.Get("Content-Type") != "text/event-stream" {
 				panic("realtime server did not open an SSE connection")
 			}
-			defer resp.Body.Close()
 
 			scanner := bufio.NewScanner(resp.Body)
 			for scanner.Scan() {


### PR DESCRIPTION
When failing to connect to SSE, we currently retry forever and immediately after each failure. This results in spamming connection attempts forever:

```
2025/01/16 18:52:23.753837 ERROR FLAGSMITH: Error connecting to realtime server: Get "http://127.0.0.1/sse/environments/ihAHot7taBsh6hbHJKdYHs/stream": dial tcp 127.0.0.1:80: connect: connection refused
2025/01/16 18:52:23.753874 ERROR FLAGSMITH: Error connecting to realtime server: Get "http://127.0.0.1/sse/environments/ihAHot7taBsh6hbHJKdYHs/stream": dial tcp 127.0.0.1:80: connect: connection refused
2025/01/16 18:52:23.753937 ERROR FLAGSMITH: Error connecting to realtime server: Get "http://127.0.0.1/sse/environments/ihAHot7taBsh6hbHJKdYHs/stream": dial tcp 127.0.0.1:80: connect: connection refused
2025/01/16 18:52:23.753982 ERROR FLAGSMITH: Error connecting to realtime server: Get "http://127.0.0.1/sse/environments/ihAHot7taBsh6hbHJKdYHs/stream": dial tcp 127.0.0.1:80: connect: connection refused
...
```

We might also want to have a limit of the number of consecutive failures, but that can come later.

Also, panic if we were able to connect to the realtime endpoint and it did not open an SSE connection. This can happen if you accidentally use any other endpoint such as `https://api.flagsmith.com`, or anything that responds over HTTP such as `https://example.com`. We might want to use something less heavy-handed than a panic to allow for cleanups, but this scenario is a clear misconfiguration where we can't do anything else.

Tested manually, but no tests were added for these scenarios.