### PR TITLE
feat!: enable poll even when realTime flag is enabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,9 +91,8 @@ func NewClient(apiKey string, options ...Option) *Client {
 		}
 		if c.config.useRealtime {
 			go c.startRealtimeUpdates(c.ctxLocalEval)
-		} else {
-			go c.pollEnvironment(c.ctxLocalEval)
 		}
+		go c.pollEnvironment(c.ctxLocalEval)
 	}
 	// Initialize analytics processor
 	if c.config.enableAnalytics {

--- a/client_test.go
+++ b/client_test.go
@@ -940,8 +940,9 @@ func TestRealtime(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	requestCount.mu.Lock()
-	assert.Equal(t, 2, requestCount.count)
+	assert.Equal(t, 3, requestCount.count)
 }
+
 func sendUpdatedAtSSEEvent(rw http.ResponseWriter, flusher http.Flusher, updatedAt float64) {
 	// Format the SSE event with the provided updatedAt value
 	sseEvent := fmt.Sprintf(`event: environment_updated


### PR DESCRIPTION
- Real time service for on-prem solution is currently unstable and development is still in-progress. 
- Requesting to enable poll even when `useRealtime` flag is enabled as failure to update environment is undesirable. 
- I understand that I can externally `pollEnvironment` but I wanted to raise a PR and get an official review to save back and forth. 