### PR TITLE
feat!: Poll and use realtime at the same time

### DIFF
--- a/realtime.go
+++ b/realtime.go
@@ -7,33 +7,21 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
 
-func (c *Client) startRealtimeUpdates(ctx context.Context) {
-	err := c.UpdateEnvironment(ctx)
-	if err != nil {
-		panic("Failed to fetch the environment while configuring real-time updates")
-	}
-
+func (c *Client) startRealtimeUpdates(ctx context.Context, stream string) {
 	env, _ := c.state.GetEnvironment()
 	envUpdatedAt := env.UpdatedAt
 	log := c.log.With("environment", env.APIKey, "current_updated_at", &envUpdatedAt)
-
-	streamPath, err := url.JoinPath(c.realtimeBaseUrl, "sse/environments", env.APIKey, "stream")
-	if err != nil {
-		log.Error("failed to build stream URL", "error", err)
-		panic(err)
-	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			resp, err := http.Get(streamPath)
+			resp, err := http.Get(stream)
 			if err != nil {
 				log.Error("failed to connect to realtime service", "error", err)
 				continue


### PR DESCRIPTION
This PR is based on top of https://github.com/Flagsmith/flagsmith-go-client/pull/151, but kept separate for easier reviewing.

## Breaking changes

### `WithRealtime` no longer disables polling

Before, using `WithRealtime` would prevent polling from happening, so that the SDK's only method of updating the environment is be via SSE. There was no way of using SSE combined with polling. This is undesirable for several reasons:

* SSE is an optional Flagsmith component that can fail just like the Flagsmith API can. Since SSE still needs the API to function, it makes sense to leverage the Flagsmith API as an alternative source via polling if SSE is unavailable. This should be handled transparently by the SDK and not require manual intervention.
* SSE does not have message delivery guarantees; it's not possible to tell whether messages have been missed for any reason. Even if we're mainly using SSE for updates, it can still be useful to set a less frequent polling interval to have some guarantee that the SDK is not running with a too outdated environment.

To disable polling, use `WithEnvironmentRefreshInterval(0)`.

### `NewClient` now returns an error if the environment could not be initialised

Previously, `NewClient` would always succeed and then try to initialise the environment in the background. If this initialisation fails and is unrecoverable (e.g. network is unavailable and we're not working offline), users would have no way of catching this besides logs.

Now, if `NewClient` needs to fetch an environment to initialise, it now blocks until the initial environment is fetched or an error is returned. The default timeout is 10 seconds, or can be changed with `WithTimeout`.

## New features

When `Client` polls for environment updates, it now checks if it already has a recent environment (i.e. younger than the polling interval) before making requests.

Real-time updates can now be used together with polling.

`WithEnvironmentRefreshInterval(0)` now prevents polling from starting. If realtime is also disabled, `NewClient` now returns an error.

Added `Client.Close`. This lets customer applications cleanly terminate the goroutines created by `NewClient`.