### PR TITLE
feat: Realtime improvements

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -10,19 +10,19 @@ const (
 	maxBackoff     = 30 * time.Second
 )
 
-// backoff handles exponential backoff with jitter
+// backoff handles exponential backoff with jitter.
 type backoff struct {
 	current time.Duration
 }
 
-// newBackoff creates a new backoff instance
+// newBackoff creates a new backoff instance.
 func newBackoff() *backoff {
 	return &backoff{
 		current: initialBackoff,
 	}
 }
 
-// next returns the next backoff duration and updates the current backoff
+// next returns the next backoff duration and updates the current backoff.
 func (b *backoff) next() time.Duration {
 	// Add jitter between 0-1s
 	backoff := b.current + time.Duration(time.Now().UnixNano()%1e9)
@@ -35,12 +35,12 @@ func (b *backoff) next() time.Duration {
 	return backoff
 }
 
-// reset resets the backoff to initial value
+// reset resets the backoff to initial value.
 func (b *backoff) reset() {
 	b.current = initialBackoff
 }
 
-// wait waits for the current backoff time, or until ctx is done
+// wait waits for the current backoff time, or until ctx is done.
 func (b *backoff) wait(ctx context.Context) {
 	select {
 	case <-ctx.Done():

--- a/backoff.go
+++ b/backoff.go
@@ -1,6 +1,9 @@
 package flagsmith
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	initialBackoff = 200 * time.Millisecond
@@ -35,4 +38,13 @@ func (b *backoff) next() time.Duration {
 // reset resets the backoff to initial value
 func (b *backoff) reset() {
 	b.current = initialBackoff
+}
+
+// wait waits for the current backoff time, or until ctx is done
+func (b *backoff) wait(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(b.next()):
+	}
 }

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,38 @@
+package flagsmith
+
+import "time"
+
+const (
+	initialBackoff = 200 * time.Millisecond
+	maxBackoff     = 30 * time.Second
+)
+
+// backoff handles exponential backoff with jitter
+type backoff struct {
+	current time.Duration
+}
+
+// newBackoff creates a new backoff instance
+func newBackoff() *backoff {
+	return &backoff{
+		current: initialBackoff,
+	}
+}
+
+// next returns the next backoff duration and updates the current backoff
+func (b *backoff) next() time.Duration {
+	// Add jitter between 0-1s
+	backoff := b.current + time.Duration(time.Now().UnixNano()%1e9)
+
+	// Double the backoff time, but cap it
+	if b.current < maxBackoff {
+		b.current *= 2
+	}
+
+	return backoff
+}
+
+// reset resets the backoff to initial value
+func (b *backoff) reset() {
+	b.current = initialBackoff
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,31 @@
+package flagsmith
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoff(t *testing.T) {
+	// Given
+	b := newBackoff()
+
+	// When
+	first := b.next()
+	second := b.next()
+	third := b.next()
+
+	// Then
+	assert.LessOrEqual(t, third, maxBackoff, "Backoff should not exceed max")
+
+	// Backoff increases across attempts
+	assert.Greater(t, second, first, "Second backoff should be greater than the first")
+	assert.Greater(t, third, second, "Third backoff should be greater than the second")
+}
+
+func TestBackoffReset(t *testing.T) {
+	b := newBackoff()
+	assert.Greater(t, b.next(), initialBackoff)
+	b.reset()
+	assert.Equal(t, initialBackoff, b.current, "Reset should return to initial backoff")
+}

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,8 +39,6 @@ type Client struct {
 	log            *slog.Logger
 	offlineHandler OfflineHandler
 	errorHandler   func(handler *FlagsmithAPIError)
-
-	once sync.Once
 }
 
 // Returns context with provided EvaluationContext instance set.

--- a/client.go
+++ b/client.go
@@ -75,7 +75,10 @@ func NewClient(apiKey string, options ...Option) *Client {
 			opt(c)
 		}
 	}
-	c.client.SetLogger(newSlogToRestyAdapter(c.log))
+	c.client = c.client.
+		SetLogger(newSlogToRestyAdapter(c.log)).
+		OnBeforeRequest(newRestyLogRequestMiddleware(c.log)).
+		OnAfterResponse(newRestyLogResponseMiddleware(c.log))
 
 	c.log.Info("initialising Flagsmith client",
 		"base_url", c.config.baseURL,

--- a/client.go
+++ b/client.go
@@ -113,7 +113,6 @@ func NewClient(apiKey string, options ...Option) *Client {
 			// Poll until we get the environment once
 			go c.pollThenStartRealtime(c.ctxLocalEval)
 		}
-
 	}
 	// Initialise analytics processor
 	if c.config.enableAnalytics {

--- a/client_test.go
+++ b/client_test.go
@@ -1003,7 +1003,7 @@ func TestWithPollingWorksWithRealtime(t *testing.T) {
 		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
 
 	// When
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Then
 	logMu.Lock()

--- a/client_test.go
+++ b/client_test.go
@@ -1013,7 +1013,7 @@ func TestWithPollingWorksWithRealtime(t *testing.T) {
 	assert.Contains(t, logStr, "worker=realtime")
 }
 
-// writerFunc implements io.Writer
+// writerFunc implements io.Writer.
 type writerFunc func(p []byte) (n int, err error)
 
 func (f writerFunc) Write(p []byte) (n int, err error) {

--- a/client_test.go
+++ b/client_test.go
@@ -977,3 +977,45 @@ func TestWithSlogLogger(t *testing.T) {
 	t.Log(logStr)
 	assert.Contains(t, logStr, "initialising Flagsmith client")
 }
+
+func TestWithPollingWorksWithRealtime(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(fixtures.EnvironmentDocumentHandler))
+	defer server.Close()
+
+	// guard against data race from goroutines logging at the same time
+	var logOutput strings.Builder
+	var logMu sync.Mutex
+	slogLogger := slog.New(slog.NewTextHandler(writerFunc(func(p []byte) (n int, err error) {
+		logMu.Lock()
+		defer logMu.Unlock()
+		return logOutput.Write(p)
+	}), &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Given
+	_ = flagsmith.NewClient(fixtures.EnvironmentAPIKey,
+		flagsmith.WithSlogLogger(slogLogger),
+		flagsmith.WithLocalEvaluation(ctx),
+		flagsmith.WithRealtime(),
+		flagsmith.WithPolling(),
+		flagsmith.WithBaseURL(server.URL+"/api/v1/"))
+
+	// When
+	time.Sleep(10 * time.Millisecond)
+
+	// Then
+	logMu.Lock()
+	logStr := logOutput.String()
+	logMu.Unlock()
+	assert.Contains(t, logStr, "worker=poll")
+	assert.Contains(t, logStr, "worker=realtime")
+}
+
+// writerFunc implements io.Writer
+type writerFunc func(p []byte) (n int, err error)
+
+func (f writerFunc) Write(p []byte) (n int, err error) {
+	return f(p)
+}

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type config struct {
 	offlineMode        bool
 	realtimeBaseUrl    string
 	useRealtime        bool
+	polling            bool
 }
 
 // defaultConfig returns default configuration.

--- a/options.go
+++ b/options.go
@@ -22,6 +22,7 @@ var _ = []Option{
 	WithCustomHeaders(nil),
 	WithDefaultHandler(nil),
 	WithProxy(""),
+	WithPolling(),
 	WithRealtime(),
 	WithRealtimeBaseURL(""),
 	WithLogger(nil),
@@ -155,5 +156,12 @@ func WithRealtimeBaseURL(url string) Option {
 			url += "/"
 		}
 		c.config.realtimeBaseUrl = url
+	}
+}
+
+// WithPolling makes it so that the client will poll for updates even when WithRealtime is used.
+func WithPolling() Option {
+	return func(c *Client) {
+		c.config.polling = true
 	}
 }

--- a/realtime.go
+++ b/realtime.go
@@ -14,18 +14,17 @@ import (
 	"github.com/Flagsmith/flagsmith-go-client/v4/flagengine/environments"
 )
 
-// realtime handles the SSE connection and reconnection logic
+// realtime handles the SSE connection and reconnection logic.
 type realtime struct {
-	client        *Client
-	ctx           context.Context
-	log           *slog.Logger
-	streamURL     string
-	envUpdatedAt  time.Time
-	backoff       *backoff
-	reconnectChan chan struct{}
+	client       *Client
+	ctx          context.Context
+	log          *slog.Logger
+	streamURL    string
+	envUpdatedAt time.Time
+	backoff      *backoff
 }
 
-// newRealtime creates a new realtime instance
+// newRealtime creates a new realtime instance.
 func newRealtime(client *Client, ctx context.Context, streamURL string, envUpdatedAt time.Time) *realtime {
 	return &realtime{
 		client: client,
@@ -40,7 +39,7 @@ func newRealtime(client *Client, ctx context.Context, streamURL string, envUpdat
 	}
 }
 
-// start begins the realtime connection process
+// start begins the realtime connection process.
 func (r *realtime) start() {
 	r.log.Debug("connecting to realtime")
 	defer func() {
@@ -59,7 +58,7 @@ func (r *realtime) start() {
 	}
 }
 
-// connect establishes and maintains the SSE connection
+// connect establishes and maintains the SSE connection.
 func (r *realtime) connect() error {
 	resp, err := http.Get(r.streamURL)
 	if err != nil {
@@ -96,7 +95,7 @@ func (r *realtime) connect() error {
 	return nil
 }
 
-// handleEvent processes a single SSE event
+// handleEvent processes a single SSE event.
 func (r *realtime) handleEvent(line string) error {
 	parsedTime, err := parseUpdatedAtFromSSE(line)
 	if err != nil {

--- a/realtime.go
+++ b/realtime.go
@@ -25,6 +25,7 @@ func (c *Client) startRealtimeUpdates(ctx context.Context) {
 		slog.String("worker", "realtime"),
 		slog.String("stream", stream_url),
 	)
+	log.Debug("connecting to realtime")
 	defer func() {
 		log.Info("realtime stopped")
 	}()

--- a/realtime.go
+++ b/realtime.go
@@ -53,7 +53,7 @@ func (r *realtime) start() {
 		default:
 			if err := r.connect(); err != nil {
 				r.log.Error("failed to connect", "error", err)
-				r.wait()
+				r.backoff.wait(r.ctx)
 			}
 		}
 	}
@@ -112,15 +112,6 @@ func (r *realtime) handleEvent(line string) error {
 		}
 	}
 	return nil
-}
-
-// wait waits for the current backoff time
-func (r *realtime) wait() {
-	select {
-	case <-r.ctx.Done():
-		return
-	case <-time.After(r.backoff.next()):
-	}
 }
 
 func parseUpdatedAtFromSSE(line string) (time.Time, error) {


### PR DESCRIPTION
### Add WithPolling option

If `WithRealtime` was used, this also enables polling in the background. This lets us have polling as a fallback for SSE

### Retry environment fetch on startup, don't panic in realtime

Instead of trying to fetch the environment document once and panicking from realtime if we couldn't, we now retry the initialisation indefinitely in a different goroutine. Once the environment initialises, we start the realtime connection as usual.

### Retry SSE reconnections with exponential backoff + jitter

Used for error handling when SSE connection fails

### Other features

* Replace logger with `slog`
* Added new `WithSlogLogger` option
* Improved log messages
* Add HTTP response and request logging