### PR TITLE
feat: Un-deprecate GetEnvironmentFlags and GetIdentityFlags, improve docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ generate-evaluation-context:
 		--package flagsmith \
 		--omit-empty \
 		--just-types-and-package \
-		- | tee evaluationcontext.go
+		-o evaluationcontext.go

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ generate-evaluation-context:
 		--package flagsmith \
 		--omit-empty \
 		--just-types-and-package \
+		--top-level EvaluationContext \
 		-o evaluationcontext.go

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ EVALUATION_CONTEXT_SCHEMA_URL ?= https://raw.githubusercontent.com/Flagsmith/fla
 
 .PHONY: generate-evaluation-context
 generate-evaluation-context:
-	npx quicktype ${EVALUATION_CONTEXT_SCHEMA_URL} \
+	curl ${EVALUATION_CONTEXT_SCHEMA_URL} | npx quicktype  \
 		--src-lang schema \
 		--lang go \
 		--package flagsmith \
 		--omit-empty \
 		--just-types-and-package \
-		> evaluationcontext.go
+		- | tee evaluationcontext.go

--- a/evaluationcontext.go
+++ b/evaluationcontext.go
@@ -1,25 +1,30 @@
 package flagsmith
 
+// EvaluationContext represents a context in which feature flags can be evaluated.
+// Flagsmith flags are always evaluated in an EnvironmentEvaluationContext, with an optional IdentityEvaluationContext.
 type EvaluationContext struct {
 	Environment *EnvironmentEvaluationContext `json:"environment,omitempty"`
-	Feature     *FeatureEvaluationContext     `json:"feature,omitempty"`
 	Identity    *IdentityEvaluationContext    `json:"identity,omitempty"`
 }
 
+// EnvironmentEvaluationContext represents a Flagsmith environment used in an EvaluationContext.
+// It is ignored if the evaluating Client was created using WithLocalEvaluation.
 type EnvironmentEvaluationContext struct {
+	// APIKey is an identifier for this environment. It is also known as the environment ID or client-side SDK key.
 	APIKey string `json:"api_key"`
 }
 
-type FeatureEvaluationContext struct {
-	Name string `json:"name"`
-}
-
+// IdentityEvaluationContext represents a Flagsmith identity within a Flagsmith environment, used in an EvaluationContext.
+// Traits are application-defined key-value pairs which can be used as part of the flag evaluation context.
+// Flagsmith will not persist Transient identities when flags are remotely evaluated.
 type IdentityEvaluationContext struct {
 	Identifier *string                            `json:"identifier,omitempty"`
 	Traits     map[string]*TraitEvaluationContext `json:"traits,omitempty"`
 	Transient  *bool                              `json:"transient,omitempty"`
 }
 
+// TraitEvaluationContext represents a single trait value used within an IdentityEvaluationContext.
+// A Transient trait will not be persisted.
 type TraitEvaluationContext struct {
 	Transient *bool       `json:"transient,omitempty"`
 	Value     interface{} `json:"value"`

--- a/evaluationcontext.go
+++ b/evaluationcontext.go
@@ -5,6 +5,7 @@ package flagsmith
 type EvaluationContext struct {
 	Environment *EnvironmentEvaluationContext `json:"environment,omitempty"`
 	Identity    *IdentityEvaluationContext    `json:"identity,omitempty"`
+	Feature     *FeatureEvaluationContext     `json:"feature,omitempty"`
 }
 
 // EnvironmentEvaluationContext represents a Flagsmith environment used in an EvaluationContext.
@@ -28,4 +29,9 @@ type IdentityEvaluationContext struct {
 type TraitEvaluationContext struct {
 	Transient *bool       `json:"transient,omitempty"`
 	Value     interface{} `json:"value"`
+}
+
+// FeatureEvaluationContext is not yet implemented.
+type FeatureEvaluationContext struct {
+	Name string `json:"name"`
 }


### PR DESCRIPTION
I cannot find a good reason to deprecate `GetEnvironmentFlags` and `GetIdentityFlags`. Having `GetFlags` as the only alternative is a worse UX. There is also not a good technical argument for this deprecation either, IMO.

`GetEnvironmentFlags` and `GetIdentityFlags` are well-known method names that are used across most Flagsmith SDKs, which are established conventions by this point:

```python
# Python
flagsmith.get_environment_flags()
```

```java
// Java
Flags flags = flagsmith.getEnvironmentFlags();
```

```csharp
// C#
var flags = _flagsmithClient.GetEnvironmentFlags().Result
```

```nodejs
// Node.js
const flags = await flagsmith.getEnvironmentFlags();
```

```ruby
# Ruby
$flags = $flagsmith.get_environment_flags()
```

```php
// PHP
$flags = $flagsmith->getEnvironmentFlags();
```

```rust
// Rust
let flags = flagsmith.get_environment_flags().unwrap();
```

```elixir
# Elixir
{:ok, %Flagsmith.Schemas.Flags{} = flags} = Flagsmith.Client.get_environment_flags(client_configuration)
```

I don't see any reason for us to move away from this convention, especially not in only one SDK. IMO, `GetFlags` is also a worse UX for the most common use cases (fetching environment and identity flags). For example, compare the following equivalent method calls:

```go
trait := flagsmith.Trait{
    TraitKey: "my_trait",
    TraitValue: "trait_value"
}
traits = []*flagsmith.Trait{&trait}
flags, err := client.GetIdentityFlags(ctx, identifier, traits)
```

```go
flags, err := client.GetFlags(ctx,
	&flagsmith.EvaluationContext{
		Identity: &flagsmith.IdentityEvaluationContext{
			Identifier: &identifier,
			Traits: map[string]*flagsmith.TraitEvaluationContext{
				"my_trait": {Value: "my_value"},
			},
		},
	})
```

For comparison, here is how OpenFeature does it:

```go
evalCtx := openfeature.NewEvaluationContext(
    "user-123",
    map[string]any{
        "company": "Initech",
    },
)
boolValue, err := client.BooleanValue("boolFlag", false, evalCtx)
```

The only reason to use `GetFlags` currently is that it's required for using transient identities and/or traits. The majority of customers using this SDK will use local evaluation, so this is not relevant for them, and they should be free to choose a simpler method call if if they prefer.

### Unrelated quicktype changes

* For some reason, pointing quicktype to a URL fails with a random `Error: Internal error: .` https://github.com/Flagsmith/flagsmith-go-client/actions/runs/15882935987/job/44787748816

* Using the `-o` option instead of redirecting the quicktype output prevents confusing errors if quicktype fails and the errors end up in the generated Go file.

* I haven't found why, but unless I specify `--top-level EvaluationContext`, the generated type name would be `Evaluationcontext`, which would break the build. Example:

```
curl 'https://raw.githubusercontent.com/Flagsmith/flagsmith/main/sdk/evaluation-context.json' | npx quicktype  \
      --src-lang schema \
      --lang go \
      --package flagsmith \
      --omit-empty \
      --just-types-and-package \
      -o evaluationcontext.go && cat evaluationcontext.go
```

```
// evaluationcontext.go
type Evaluationcontext struct { // should be EvaluationContext
	Environment *EnvironmentEvaluationContext `json:"environment,omitempty"`
	Feature     *FeatureEvaluationContext     `json:"feature,omitempty"`
	Identity    *IdentityEvaluationContext    `json:"identity,omitempty"`
}
```