### PR TITLE
fix(ci): Fix flaky TestIdentityGetAllFeatureStatesWithTraits

### DIFF
--- a/flagengine/engine_test.go
+++ b/flagengine/engine_test.go
@@ -110,7 +110,7 @@ func TestIdentityGetAllFeatureStatesWithTraits(t *testing.T) {
 	}
 
 	allFeatureStates := flagengine.GetIdentityFeatureStates(envWithSegmentOverride, identity, traitModels...)
-	var found bool
+	found := false
 	for _, fs := range allFeatureStates {
 		if fs.RawValue == "segment_override" {
 			found = true

--- a/flagengine/engine_test.go
+++ b/flagengine/engine_test.go
@@ -110,8 +110,14 @@ func TestIdentityGetAllFeatureStatesWithTraits(t *testing.T) {
 	}
 
 	allFeatureStates := flagengine.GetIdentityFeatureStates(envWithSegmentOverride, identity, traitModels...)
-
-	assert.Equal(t, "segment_override", allFeatureStates[0].RawValue)
+	var found bool
+	for _, fs := range allFeatureStates {
+		if fs.RawValue == "segment_override" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected to find feature state with segment_override value")
 }
 
 func TestEnvironmentGetAllFeatureStates(t *testing.T) {


### PR DESCRIPTION
`allFeatureStates` is built by iterating through a map, so we can't guarantee that `segment_override` will always be on the first element.

Example failure: https://github.com/Flagsmith/flagsmith-go-client/actions/runs/15901727156/job/44847138946?pr=162#step:8:844