### PR TITLE
docs: removing hero image from SDK readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img width="100%" src="https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png"/>
-
 [![Go](https://github.com/flagsmith/flagsmith-go-client/workflows/Go/badge.svg?branch=main)](https://github.com/flagsmith/flagsmith-go-client/actions)
 [![GoReportCard](https://goreportcard.com/badge/github.com/flagsmith/flagsmith-go-client)](https://goreportcard.com/report/github.com/flagsmith/flagsmith-go-client)
 [![GoDoc](https://godoc.org/github.com/flagsmith/flagsmith-go-client/v4?status.svg)](https://pkg.go.dev/github.com/Flagsmith/flagsmith-go-client/v4#section-documentation)


### PR DESCRIPTION
To remove the risk of these breaking when we make changes in flagsmith/flagsmith we're removing these image references from the readme.md files of the SDK repos.