### PR TITLE
fix: log arguments are not formatted

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -35,15 +35,15 @@ func newSlogToRestyAdapter(logger *slog.Logger) *slogToRestyAdapter {
 }
 
 func (l *slogToRestyAdapter) Errorf(format string, v ...interface{}) {
-	l.logger.Error(format, v...)
+	l.logger.Error(fmt.Sprintf(format, v...))
 }
 
 func (l *slogToRestyAdapter) Warnf(format string, v ...interface{}) {
-	l.logger.Warn(format, v...)
+	l.logger.Warn(fmt.Sprintf(format, v...))
 }
 
 func (l *slogToRestyAdapter) Debugf(format string, v ...interface{}) {
-	l.logger.Debug(format, v...)
+	l.logger.Debug(fmt.Sprintf(format, v...))
 }
 
 // slogToLoggerAdapter adapts a slog.Logger to our Logger interface.

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,54 @@
+package flagsmith
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlogToRestyAdapter_Errorf(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	adapter := newSlogToRestyAdapter(logger)
+
+	adapter.Errorf("test error: %s", "bad")
+
+	output := buf.String()
+	assert.Contains(t, output, "test error: bad")
+	assert.Contains(t, output, "level=ERROR")
+}
+
+func TestSlogToRestyAdapter_Warnf(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	adapter := newSlogToRestyAdapter(logger)
+
+	adapter.Warnf("test warning: %s: %d", "warn", 42)
+
+	output := buf.String()
+	assert.Contains(t, output, "test warning: warn: 42")
+	assert.Contains(t, output, "level=WARN")
+}
+
+func TestSlogToRestyAdapter_Debugf(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	adapter := newSlogToRestyAdapter(logger)
+
+	adapter.Debugf("debug info: %s", "details")
+
+	output := buf.String()
+	assert.Contains(t, output, "debug info: details")
+	assert.Contains(t, output, "level=DEBUG")
+}


### PR DESCRIPTION
This fixes a problem with unformatted Sprintf-style strings in the logs.
Added tests to verify logs being correctly formatted.

Solves: #179 