### PR TITLE
fix: CI lint silently breaks whenever a new Go stable is released

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: recursive
         
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
 
     - name: Build
       run: go build -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,42 @@
-linters-settings:
-  misspell:
-    locale: UK
-    ignore-words:
-      - standardize  # hujson library uses US spelling
+version: "2"
 linters:
+  default: none
   enable:
     - contextcheck
     - errcheck
     - godot
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
     - unused
     - whitespace
-  disable-all: true
+  settings:
+    misspell:
+      locale: UK
+      ignore-rules:
+        - standardize  # hujson library uses US spelling
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-run:
-  timeout: 5m
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,17 +16,6 @@ linters:
       locale: UK
       ignore-rules:
         - standardize  # hujson library uses US spelling
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -34,9 +23,3 @@ formatters:
   enable:
     - gofmt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/flagengine/utils/time.go
+++ b/flagengine/utils/time.go
@@ -17,5 +17,5 @@ func (i *ISOTime) UnmarshalJSON(bytes []byte) (err error) {
 }
 
 func (i *ISOTime) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + i.Time.Format(time.RFC3339) + `"`), nil
+	return []byte(`"` + i.Format(time.RFC3339) + `"`), nil
 }

--- a/realtime.go
+++ b/realtime.go
@@ -64,7 +64,7 @@ func (r *realtime) connect() error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("error response connecting to stream: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
Every pull request opened on this repository today fails the lint stage with errors unrelated to the change under review, because the bundled type-checker is built against the Go 1.24 standard library while the workflow runs on `stable`, which advanced to Go 1.26 with [its February 2026 release](https://go.dev/doc/devel/release). The break is pure toolchain drift; the source code is otherwise clean. Restoring CI requires moving the lint action to its [v8+ line](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0), which in turn requires migrating the lint configuration to the [golangci-lint v2 schema](https://golangci-lint.run/product/migration-guide/). Going to v2 also drops the bundled suppressions v1 inherited by default, surfacing two findings the project had been silently hiding — both addressed inline rather than re-suppressed.

## Changes

- [x] Pull requests that touch no CI configuration pass the lint stage on the most recent released Go.
- [x] Lint findings previously hidden by the toolchain's default suppressions are made explicit in source.
- [x] Future automated bumps to the lint action land cleanly because the configuration matches current upstream conventions.

Closes #206

Review effort: 2/5
