### PR TITLE
fix: release workflow fails to publish artifacts on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The release workflow is currently failing for every tag push because the `--rm-dist` flag was removed in [GoReleaser v2](https://goreleaser.com/deprecations/#-rm-dist), and `goreleaser-action@v7` (recently adopted via #202) locks GoReleaser to `~> v2`. The `v5.1.0` release page already shows the consequence — tag and changelog were created, but no source archives or checksums were uploaded.

## Changes

- [x] Releases publish their artifacts again on tag push, so consumers can pull source archives and checksums from the release page rather than only from the proxy.

Review effort: 1/5
