### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "flagengine/engine-test-data"]
 	path = flagengine/engine-test-data
 	url = git@github.com:Flagsmith/engine-test-data.git
-	tag = v3.5.0
+	tag = v3.7.0

--- a/flagengine/engine_eval/evaluator.go
+++ b/flagengine/engine_eval/evaluator.go
@@ -58,12 +58,34 @@ func contextMatchesSegmentRule(ec *EngineEvaluationContext, segmentRule *Segment
 		}
 	}
 
-	for i := range segmentRule.Rules {
-		if !contextMatchesSegmentRule(ec, &segmentRule.Rules[i], segmentKey) {
+	return matchesSubRulesByRuleType(ec, segmentRule.Rules, segmentRule.Type, segmentKey)
+}
+
+// matchesSubRulesByRuleType evaluates sub-rules using the parent rule's type (ALL/ANY/NONE).
+func matchesSubRulesByRuleType(ec *EngineEvaluationContext, subRules []SegmentRule, ruleType Type, segmentKey string) bool {
+	if len(subRules) == 0 {
+		return true
+	}
+	for i := range subRules {
+		subRuleMatches := contextMatchesSegmentRule(ec, &subRules[i], segmentKey)
+		switch ruleType {
+		case All:
+			if !subRuleMatches {
+				return false
+			}
+		case None:
+			if subRuleMatches {
+				return false
+			}
+		case Any:
+			if subRuleMatches {
+				return true
+			}
+		default:
 			return false
 		}
 	}
-	return true
+	return ruleType != Any
 }
 
 func matchPercentageSplit(ec *EngineEvaluationContext, segmentCondition *Condition, segmentKey string, contextValue ContextValue) bool {


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes 3 new sub-rule type test cases)
- [x] Verified tests fail before the fix
- [x] Applied the fix
- [x] Verified all tests pass after the fix