### PR TITLE
ci: track engine-test-data semver tags via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
         {
             "matchManagers": ["github-actions", "gomod", "git-submodules"],
             "enabled": true
+        },
+        {
+            "matchManagers": ["git-submodules"],
+            "versioning": "semver-coerced"
         }
     ]
 }


### PR DESCRIPTION
## Problem

The `git-submodules` manager defaults to `versioning: "git"`, which treats the `.gitmodules` `branch = v3.x.y` value as an **opaque git ref**. Renovate only refreshes that tag's (immutable) commit SHA and never proposes a newer tag, so the `engine-test-data` submodule has only ever been bumped **manually** — it stayed on `v3.7.0` even after `v3.10.0` was released.

## Fix

Set `versioning: "semver-coerced"` on the `git-submodules` manager so Renovate ranks the semver tags and opens bump PRs (e.g. `v3.7.0` → `v3.10.0`).

## Notes

`.gitmodules` already uses the `branch` field, so no change is needed there. This is a config-only change; the actual version bump will come as a follow-up Renovate PR.
